### PR TITLE
Remove cdeps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,10 @@ jobs:
     docker:
       # specify the version
       - image: circleci/golang:1.9.2
-
-			- image: circleci/postgres:9.4.12-alpine
-							environment:
-								POSTGRES_USER: root
-								POSTGRES_DB: circle_test
+      - image: circleci/postgres:9.4.12-alpine
+        environment:
+          POSTGRES_USER: root
+          POSTGRES_DB: circle_test
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -26,7 +25,7 @@ jobs:
     steps:
       - checkout
 
-			- run:
+      - run:
           name: Waiting for Postgres to be ready
           command: |
             for i in `seq 1 10`;
@@ -38,11 +37,11 @@ jobs:
             echo Failed waiting for Postgres && exit 1
 
       - run:
-					name: Fetch dependencies
-					command: go get -v -t -d ./...
+          name: Fetch dependencies
+          command: go get -v -t -d ./...
 
       - run:
-					name: Run tests
-					environment:
-						TEST_DSN: "postgres://root@localhost:5432/circle_test?sslmode=disable"
-					command: go test -v ./...
+          name: Run tests
+          environment:
+            TEST_DSN: "postgres://root@localhost:5432/circle_test?sslmode=disable"
+          command: go test -v ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,11 @@ jobs:
       # specify the version
       - image: circleci/golang:1.9.2
 
+			- image: circleci/postgres:9.4.12-alpine
+							environment:
+								POSTGRES_USER: root
+								POSTGRES_DB: circle_test
+
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
@@ -21,6 +26,23 @@ jobs:
     steps:
       - checkout
 
-      # specify any bash command here prefixed with `run: `
-      - run: go get -v -t -d ./...
-      - run: go test -v ./...
+			- run:
+          name: Waiting for Postgres to be ready
+          command: |
+            for i in `seq 1 10`;
+            do
+              nc -z localhost 5432 && echo Success && exit 0
+              echo -n .
+              sleep 1
+            done
+            echo Failed waiting for Postgres && exit 1
+
+      - run:
+					name: Fetch dependencies
+					command: go get -v -t -d ./...
+
+      - run:
+					name: Run tests
+					environment:
+						TEST_DSN: "postgres://root@localhost:5432/circle_test?sslmode=disable"
+					command: go test -v ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.9.2
+
+# Ensure go bin directory exists
+RUN mkdir -p /go/bin
+
+# Make and set the working directory
+RUN mkdir -p /go/src/app
+WORKDIR /go/src/app
+
+# Add app source to working directory
+ADD . /go/src/app
+
+# Fetch dependencies
+RUN go get -u github.com/golang/dep/...
+RUN dep ensure
+
+# Build the app
+RUN go build -o /go/bin/recall /go/src/app/main.go

--- a/bin/wait-for-it.sh
+++ b/bin/wait-for-it.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+
+cmdname=$(basename $0)
+
+echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $TIMEOUT -gt 0 ]]; then
+        echoerr "$cmdname: waiting $TIMEOUT seconds for $HOST:$PORT"
+    else
+        echoerr "$cmdname: waiting for $HOST:$PORT without a timeout"
+    fi
+    start_ts=$(date +%s)
+    while :
+    do
+        if [[ $ISBUSY -eq 1 ]]; then
+            nc -z $HOST $PORT
+            result=$?
+        else
+            (echo > /dev/tcp/$HOST/$PORT) >/dev/null 2>&1
+            result=$?
+        fi
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echoerr "$cmdname: $HOST:$PORT is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $QUIET -eq 1 ]]; then
+        timeout $BUSYTIMEFLAG $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    else
+        timeout $BUSYTIMEFLAG $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    fi
+    PID=$!
+    trap "kill -INT -$PID" INT
+    wait $PID
+    RESULT=$?
+    if [[ $RESULT -ne 0 ]]; then
+        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
+    fi
+    return $RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        hostport=(${1//:/ })
+        HOST=${hostport[0]}
+        PORT=${hostport[1]}
+        shift 1
+        ;;
+        --child)
+        CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        STRICT=1
+        shift 1
+        ;;
+        -h)
+        HOST="$2"
+        if [[ $HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        PORT="$2"
+        if [[ $PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        TIMEOUT="$2"
+        if [[ $TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$HOST" == "" || "$PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+TIMEOUT=${TIMEOUT:-15}
+STRICT=${STRICT:-0}
+CHILD=${CHILD:-0}
+QUIET=${QUIET:-0}
+
+# check to see if timeout is from busybox?
+# check to see if timeout is from busybox?
+TIMEOUT_PATH=$(realpath $(which timeout))
+if [[ $TIMEOUT_PATH =~ "busybox" ]]; then
+        ISBUSY=1
+        BUSYTIMEFLAG="-t"
+else
+        ISBUSY=0
+        BUSYTIMEFLAG=""
+fi
+
+if [[ $CHILD -gt 0 ]]; then
+    wait_for
+    RESULT=$?
+    exit $RESULT
+else
+    if [[ $TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        RESULT=$?
+    else
+        wait_for
+        RESULT=$?
+    fi
+fi
+
+if [[ $CLI != "" ]]; then
+    if [[ $RESULT -ne 0 && $STRICT -eq 1 ]]; then
+        echoerr "$cmdname: strict mode, refusing to execute subprocess"
+        exit $RESULT
+    fi
+    exec "${CLI[@]}"
+else
+    exit $RESULT
+fi

--- a/cmd/createuser.go
+++ b/cmd/createuser.go
@@ -16,12 +16,11 @@ var createuser = subcmd.Command{
 	UsageLine: "createuser",
 	Short:     "create a new user in the database",
 	Run: func(cmd *subcmd.Command, args []string) {
-		dbdriver := cmd.Flag.String("dbdriver", "sqlite3", "driver of the database you intend to use (sqlite3, postgres)")
-		dbdsn := cmd.Flag.String("dsn", "gorecall.db", "data source name")
+		dbdsn := cmd.Flag.String("dsn", "postgres://recall:recall@localhost/recall?sslmode=disable", "data source name")
 		cmd.ParseFlags(args)
 
 		db, err := database.Connect(database.Options{
-			Driver: *dbdriver,
+			Driver: "postgres",
 			DSN:    *dbdsn,
 		})
 		if err != nil {

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -15,13 +15,12 @@ var index = subcmd.Command{
 	UsageLine: "index",
 	Short:     "update the search index",
 	Run: func(cmd *subcmd.Command, args []string) {
-		dbdriver := cmd.Flag.String("dbdriver", "sqlite3", "driver of the database you intend to use (sqlite3, postgres)")
-		dbdsn := cmd.Flag.String("dsn", "gorecall.db", "data source name")
+		dbdsn := cmd.Flag.String("dsn", "postgres://recall:recall@localhost/recall?sslmode=disable", "data source name")
 		indexname := cmd.Flag.String("indexname", "gorecall.idx", "path to search index")
 		cmd.ParseFlags(args)
 
 		db, err := database.Connect(database.Options{
-			Driver: *dbdriver,
+			Driver: "postgres",
 			DSN:    *dbdsn,
 		})
 		if err != nil {

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -22,13 +22,13 @@ var migrate = subcmd.Command{
 
 		db, err := database.Connect(dbopts)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Println("error connecting to database:", err)
 			os.Exit(1)
 		}
 
 		err = database.Setup(dbopts, db)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Println("error migrating databaseL", err)
 			os.Exit(0)
 		}
 

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -12,12 +12,11 @@ var migrate = subcmd.Command{
 	UsageLine: "migrate",
 	Short:     "run any pending database migrations",
 	Run: func(cmd *subcmd.Command, args []string) {
-		dbdriver := cmd.Flag.String("dbdriver", "sqlite3", "driver of the database you intend to use (sqlite3, postgres)")
-		dbdsn := cmd.Flag.String("dsn", "gorecall.db", "data source name")
+		dbdsn := cmd.Flag.String("dsn", "postgres://recall:recall@localhost/recall?sslmode=disable", "data source name")
 		cmd.ParseFlags(args)
 
 		dbopts := database.Options{
-			Driver: *dbdriver,
+			Driver: "postgres",
 			DSN:    *dbdsn,
 		}
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -34,31 +34,31 @@ var serve = subcmd.Command{
 			DSN:    *dbdsn,
 		})
 		if err != nil {
-			fmt.Println(err)
+			fmt.Println("error connecting to database:", err)
 			os.Exit(1)
 		}
 
 		index, err := bleve.Open(*indexname)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Println("error opening index:", err)
 			os.Exit(1)
 		}
 
 		uRepo, err := datastore.NewUserRepo(db)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Println("error creating user repo:", err)
 			os.Exit(1)
 		}
 
 		bmRepo, err := datastore.NewBookmarkRepo(db)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Println("error creating bookmark repo:", err)
 			os.Exit(1)
 		}
 
 		trRepo, err := datastore.NewTagRepo(db)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Println("error creating tag repo:", err)
 			os.Exit(1)
 		}
 
@@ -69,7 +69,7 @@ var serve = subcmd.Command{
 
 		dec, err := base64.StdEncoding.DecodeString(*secret)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Println("could not decode secret:", err)
 			os.Exit(1)
 		}
 		store := sessions.NewCookieStore(dec)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -21,8 +21,7 @@ var serve = subcmd.Command{
 	Short:     "serve the web app using one of the supported methods",
 	Run: func(cmd *subcmd.Command, args []string) {
 		addr := cmd.Flag.String("addr", ":8080", "the address to bind to when using the http server")
-		dbdriver := cmd.Flag.String("dbdriver", "sqlite3", "driver of the database you intend to use (sqlite3, postgres)")
-		dbdsn := cmd.Flag.String("dsn", "gorecall.db", "data source name")
+		dbdsn := cmd.Flag.String("dsn", "postgres://recall:recall@localhost/recall?sslmode=disable", "data source name")
 		indexname := cmd.Flag.String("indexname", "gorecall.idx", "path to index directory")
 		usecgi := cmd.Flag.Bool("cgi", false, "Serve app using cgi")
 		usefcgi := cmd.Flag.Bool("fcgi", false, "Serve app using fastcgi")
@@ -31,7 +30,7 @@ var serve = subcmd.Command{
 		cmd.ParseFlags(args)
 
 		db, err := database.Connect(database.Options{
-			Driver: *dbdriver,
+			Driver: "postgres",
 			DSN:    *dbdsn,
 		})
 		if err != nil {

--- a/cmd/webinfo.go
+++ b/cmd/webinfo.go
@@ -15,13 +15,12 @@ var webinfo = subcmd.Command{
 	UsageLine: "webinfo",
 	Short:     "process actual web requests for bookmark links and populate metadata fields",
 	Run: func(cmd *subcmd.Command, args []string) {
-		dbdriver := cmd.Flag.String("dbdriver", "sqlite3", "driver of the database you intend to use (sqlite3, postgres)")
-		dbdsn := cmd.Flag.String("dsn", "gorecall.db", "data source name")
+		dbdsn := cmd.Flag.String("dsn", "postgres://recall:recall@localhost/recall?sslmode=disable", "data source name")
 		concurrency := cmd.Flag.Int("concurrency", 10, "max number of conncurrent requests")
 		cmd.ParseFlags(args)
 
 		dbopts := database.Options{
-			Driver: *dbdriver,
+			Driver: "postgres",
 			DSN:    *dbdsn,
 		}
 

--- a/database/db.go
+++ b/database/db.go
@@ -90,6 +90,13 @@ const (
 		CREATE UNIQUE INDEX tagging
 		ON bookmark_tags (bookmark_id, tag_id);
 	`
+
+	postgresteardown = `
+		DROP TABLE bookmarks;
+		DROP TABLE tags;
+		DROP TABLE users;
+		DROP TABLE bookmark_tags;
+	`
 )
 
 type Options struct {
@@ -125,6 +132,20 @@ func Connect(opts Options) (*sqlx.DB, error) {
 	}
 
 	return db, nil
+}
+
+// WARNING: This will drop all database objects
+func Teardown(opts Options, db *sqlx.DB) error {
+	switch opts.Driver {
+	case "postgres":
+		_, err := db.Exec(postgresteardown)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("database: no teardown for driver %s", opts.Driver)
+	}
+	return nil
 }
 
 // Apply the correct database schema based on options.Driver

--- a/database/db.go
+++ b/database/db.go
@@ -56,10 +56,10 @@ const (
 			title TEXT,
 			url TEXT UNIQUE,
 			icon TEXT,
-			media_type TEXT DEFAULT "",
-			description TEXT DEFAULT "",
-			keywords TEXT DEFAULT "",
-			text_content TEXT DEFAULT "",
+			media_type TEXT DEFAULT '',
+			description TEXT DEFAULT '',
+			keywords TEXT DEFAULT '',
+			text_content TEXT DEFAULT '',
 			status INTEGER DEFAULT 0,
 			created TIMESTAMP DEFAULT NOW()
 		);

--- a/datastore/bookmark_test.go
+++ b/datastore/bookmark_test.go
@@ -2,6 +2,8 @@ package datastore
 
 import (
 	"testing"
+
+	"github.com/jmoiron/sqlx"
 )
 
 func TestNewBookmarkRepo(t *testing.T) {
@@ -14,222 +16,223 @@ func TestNewBookmarkRepo(t *testing.T) {
 }
 
 func TestBookmarkRepoCreate(t *testing.T) {
-	db, bookmarkRepo := bookmarkRepoTestDeps()
-	defer db.Close()
+	withDatabaseFixtures(t, func(db *sqlx.DB) {
+		bookmarkRepo := bookmarkRepoTestDeps(db)
 
-	bm := &Bookmark{
-		Title: "Create",
-	}
+		bm := &Bookmark{
+			Title: "Create",
+		}
 
-	bm, err := bookmarkRepo.Create(bm)
-	if err != nil {
-		t.Error("expected", nil)
-		t.Error("got     ", err)
-	}
-	if bm.Created.IsZero() {
-		t.Error("expected", "Created to be set")
-		t.Error("got     ", "Zero value date")
-	}
-	if bm.ID == 0 {
-		t.Error("expected", "ID to be set by database")
-		t.Error("got     ", "Zero value ID")
-	}
-	if bm.Title != "Create" {
-		t.Error("expected", "Title to be Create")
-		t.Error("got     ", bm.Title)
-	}
+		bm, err := bookmarkRepo.Create(bm)
+		if err != nil {
+			t.Error("expected", nil)
+			t.Error("got     ", err)
+		}
+		if bm.Created.IsZero() {
+			t.Error("expected", "Created to be set")
+			t.Error("got     ", "Zero value date")
+		}
+		if bm.ID == 0 {
+			t.Error("expected", "ID to be set by database")
+			t.Error("got     ", "Zero value ID")
+		}
+		if bm.Title != "Create" {
+			t.Error("expected", "Title to be Create")
+			t.Error("got     ", bm.Title)
+		}
+	})
 }
 
 func TestBookmarkRepoGetByID(t *testing.T) {
-	db, bookmarkRepo := bookmarkRepoTestDeps()
-	loadDefaultFixture(db)
-	defer db.Close()
+	withDatabaseFixtures(t, func(db *sqlx.DB) {
+		bookmarkRepo := bookmarkRepoTestDeps(db)
 
-	bm, err := bookmarkRepo.GetByID(1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if bm.Title != "bm1" {
-		t.Error("expected", "bm1")
-		t.Error("got     ", bm.Title)
-	}
+		bm, err := bookmarkRepo.GetByID(1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if bm.Title != "bm1" {
+			t.Error("expected", "bm1")
+			t.Error("got     ", bm.Title)
+		}
+	})
 }
 
 func TestBookmarkRepoGetByURL(t *testing.T) {
-	db, bookmarkRepo := bookmarkRepoTestDeps()
-	loadDefaultFixture(db)
-	defer db.Close()
+	withDatabaseFixtures(t, func(db *sqlx.DB) {
+		bookmarkRepo := bookmarkRepoTestDeps(db)
 
-	_, err := bookmarkRepo.GetByURL("bmurl1")
-	if err != nil {
-		t.Fatal(err)
-	}
+		_, err := bookmarkRepo.GetByURL("bmurl1")
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 }
 
 func TestBookmarkRepoGetAll(t *testing.T) {
-	db, bookmarkRepo := bookmarkRepoTestDeps()
-	loadDefaultFixture(db)
-	defer db.Close()
+	withDatabaseFixtures(t, func(db *sqlx.DB) {
+		bookmarkRepo := bookmarkRepoTestDeps(db)
 
-	bms, err := bookmarkRepo.GetAll()
-	if err != nil {
-		t.Error(err)
-		t.Fail()
-	}
-	if len(bms) != 5 {
-		t.Error("expected", "5 Bookmarks")
-		t.Error("got     ", len(bms))
-	}
+		bms, err := bookmarkRepo.GetAll()
+		if err != nil {
+			t.Error(err)
+			t.Fail()
+		}
+		if len(bms) != 5 {
+			t.Error("expected", "5 Bookmarks")
+			t.Error("got     ", len(bms))
+		}
+	})
 }
 
 func TestBookmarkRepoList(t *testing.T) {
-	db, bookmarkRepo := bookmarkRepoTestDeps()
-	loadDefaultFixture(db)
-	defer db.Close()
+	withDatabaseFixtures(t, func(db *sqlx.DB) {
+		bookmarkRepo := bookmarkRepoTestDeps(db)
 
-	opts := ListOptions{
-		PerPage: 3,
-		Page:    0,
-		OrderBy: "created",
-		Order:   "asc",
-	}
+		opts := ListOptions{
+			PerPage: 3,
+			Page:    0,
+			OrderBy: "created",
+			Order:   "asc",
+		}
 
-	bms, err := bookmarkRepo.List(opts)
-	if err != nil {
-		t.Error("expected", "no error")
-		t.Error("got     ", err)
-	}
-	if len(bms) != 3 {
-		t.Error("expected", "3 bookmarks per page")
-		t.Error("got     ", len(bms))
-	}
+		bms, err := bookmarkRepo.List(opts)
+		if err != nil {
+			t.Error("expected", "no error")
+			t.Error("got     ", err)
+		}
+		if len(bms) != 3 {
+			t.Error("expected", "3 bookmarks per page")
+			t.Error("got     ", len(bms))
+		}
+	})
 }
 
 func TestBookmarkCount(t *testing.T) {
-	db, bookmarkRepo := bookmarkRepoTestDeps()
-	loadDefaultFixture(db)
-	defer db.Close()
+	withDatabaseFixtures(t, func(db *sqlx.DB) {
+		bookmarkRepo := bookmarkRepoTestDeps(db)
 
-	count, err := bookmarkRepo.Count()
-	if err != nil {
-		t.Error("expected", "no error")
-		t.Error("got     ", err)
-	}
+		count, err := bookmarkRepo.Count()
+		if err != nil {
+			t.Error("expected", "no error")
+			t.Error("got     ", err)
+		}
 
-	if count != 5 {
-		t.Error("expected", "5")
-		t.Error("got     ", count)
-	}
+		if count != 5 {
+			t.Error("expected", "5")
+			t.Error("got     ", count)
+		}
+	})
 }
 
 func TestBookmarkListTags(t *testing.T) {
-	db, bookmarkRepo := bookmarkRepoTestDeps()
-	loadDefaultFixture(db)
-	defer db.Close()
+	withDatabaseFixtures(t, func(db *sqlx.DB) {
+		bookmarkRepo := bookmarkRepoTestDeps(db)
 
-	tags, err := bookmarkRepo.ListTags(1)
-	if err != nil {
-		t.Error("expected", "no error")
-		t.Error("got     ", err)
-	}
-	if len(tags) != 3 {
-		t.Error("expected", "bookmark to have 3 tags")
-		t.Error("got     ", len(tags))
-	}
-	if tags[0].Label != "tag1" {
-		t.Error("expected", "first tag to have label tag1")
-		t.Error("got     ", tags[0].Label)
-	}
+		tags, err := bookmarkRepo.ListTags(1)
+		if err != nil {
+			t.Error("expected", "no error")
+			t.Error("got     ", err)
+		}
+		if len(tags) != 3 {
+			t.Error("expected", "bookmark to have 3 tags")
+			t.Error("got     ", len(tags))
+		}
+		if tags[0].Label != "tag1" {
+			t.Error("expected", "first tag to have label tag1")
+			t.Error("got     ", tags[0].Label)
+		}
+	})
 }
 
 func testBookmarkCountTags(t *testing.T) {
-	db, bookmarkRepo := bookmarkRepoTestDeps()
-	loadDefaultFixture(db)
-	defer db.Close()
+	withDatabaseFixtures(t, func(db *sqlx.DB) {
+		bookmarkRepo := bookmarkRepoTestDeps(db)
 
-	count, err := bookmarkRepo.CountTags(2)
-	if err != nil {
-		t.Error("expected", "no error")
-		t.Error("got     ", err)
-	}
-	if count != 2 {
-		t.Error("expected", "count = 2")
-		t.Error("got     ", count)
-	}
+		count, err := bookmarkRepo.CountTags(2)
+		if err != nil {
+			t.Error("expected", "no error")
+			t.Error("got     ", err)
+		}
+		if count != 2 {
+			t.Error("expected", "count = 2")
+			t.Error("got     ", count)
+		}
+	})
 }
 
 func testBookmarkAddTag(t *testing.T) {
-	db, bookmarkRepo := bookmarkRepoTestDeps()
-	loadDefaultFixture(db)
-	defer db.Close()
+	withDatabaseFixtures(t, func(db *sqlx.DB) {
+		bookmarkRepo := bookmarkRepoTestDeps(db)
 
-	err := bookmarkRepo.AddTag(5, 3)
-	if err != nil {
-		t.Error("expected", "no error")
-		t.Error("got     ", err)
-	}
+		err := bookmarkRepo.AddTag(5, 3)
+		if err != nil {
+			t.Error("expected", "no error")
+			t.Error("got     ", err)
+		}
+	})
 }
 
 func testBookmarkRemoveTag(t *testing.T) {
-	db, bookmarkRepo := bookmarkRepoTestDeps()
-	loadDefaultFixture(db)
-	defer db.Close()
+	withDatabaseFixtures(t, func(db *sqlx.DB) {
+		bookmarkRepo := bookmarkRepoTestDeps(db)
 
-	err := bookmarkRepo.RemoveTag(1, 3)
-	if err != nil {
-		t.Error("expected", "no error")
-		t.Error("got     ", err)
-	}
+		err := bookmarkRepo.RemoveTag(1, 3)
+		if err != nil {
+			t.Error("expected", "no error")
+			t.Error("got     ", err)
+		}
 
-	count, err := bookmarkRepo.CountTags(1)
-	if err != nil {
-		t.Error(err)
-	}
-	if count != 2 {
-		t.Error("expected", "1 less tag")
-		t.Error("got     ", count)
-	}
+		count, err := bookmarkRepo.CountTags(1)
+		if err != nil {
+			t.Error(err)
+		}
+		if count != 2 {
+			t.Error("expected", "1 less tag")
+			t.Error("got     ", count)
+		}
+	})
 }
 
 func TestBookmarkDelete(t *testing.T) {
-	db, bookmarkRepo := bookmarkRepoTestDeps()
-	loadDefaultFixture(db)
-	defer db.Close()
+	withDatabaseFixtures(t, func(db *sqlx.DB) {
+		bookmarkRepo := bookmarkRepoTestDeps(db)
 
-	err := bookmarkRepo.Delete(1)
-	if err != nil {
-		t.Error(err)
-	}
+		err := bookmarkRepo.Delete(1)
+		if err != nil {
+			t.Error(err)
+		}
 
-	err = bookmarkRepo.Delete(1000)
-	if err == nil {
-		t.Error("expected error got nil")
-	}
+		err = bookmarkRepo.Delete(1000)
+		if err == nil {
+			t.Error("expected error got nil")
+		}
+	})
 }
 
 func TestBookmarkRepoUpdate(t *testing.T) {
-	db, bookmarkRepo := bookmarkRepoTestDeps()
-	loadDefaultFixture(db)
-	defer db.Close()
+	withDatabaseFixtures(t, func(db *sqlx.DB) {
+		bookmarkRepo := bookmarkRepoTestDeps(db)
 
-	bm := &Bookmark{
-		ID:    1,
-		Title: "Updated bookmark",
-		URL:   "http://updated.com",
-	}
+		bm := &Bookmark{
+			ID:    1,
+			Title: "Updated bookmark",
+			URL:   "http://updated.com",
+		}
 
-	bm, err := bookmarkRepo.Update(bm)
-	if err != nil {
-		t.Error(err)
-	}
+		bm, err := bookmarkRepo.Update(bm)
+		if err != nil {
+			t.Error(err)
+		}
 
-	bookmark, err := bookmarkRepo.GetByID(1)
-	if err != nil {
-		t.Error(err)
-	}
+		bookmark, err := bookmarkRepo.GetByID(1)
+		if err != nil {
+			t.Error(err)
+		}
 
-	if bookmark.Title != "Updated bookmark" {
-		t.Error("expected", "Updated bookmark")
-		t.Error("got     ", bookmark.Title)
-	}
+		if bookmark.Title != "Updated bookmark" {
+			t.Error("expected", "Updated bookmark")
+			t.Error("got     ", bookmark.Title)
+		}
+	})
 }

--- a/datastore/bookmark_test.go
+++ b/datastore/bookmark_test.go
@@ -16,7 +16,7 @@ func TestNewBookmarkRepo(t *testing.T) {
 }
 
 func TestBookmarkRepoCreate(t *testing.T) {
-	withDatabaseFixtures(t, func(db *sqlx.DB) {
+	withDatabase(t, func(db *sqlx.DB) {
 		bookmarkRepo := bookmarkRepoTestDeps(db)
 
 		bm := &Bookmark{

--- a/datastore/helpers_test.go
+++ b/datastore/helpers_test.go
@@ -39,6 +39,7 @@ func userRepoTestDeps() (*sqlx.DB, *userRepo) {
 }
 
 // Returns in memory database with schema applied
+// TODO: test against a real postgres instance if available
 func testDB() *sqlx.DB {
 	db, err := sqlx.Open("sqlite3", ":memory:")
 	if err != nil {

--- a/datastore/helpers_test.go
+++ b/datastore/helpers_test.go
@@ -1,6 +1,7 @@
 package datastore
 
 import (
+	"os"
 	"testing"
 
 	"github.com/efy/gorecall/database"
@@ -58,13 +59,19 @@ func testDB() *sqlx.DB {
 // Function to wrap up tests against a postgres instance
 // handles database setup and teardown
 func withDatabase(t *testing.T, run func(db *sqlx.DB)) {
-	db, err := sqlx.Connect("sqlite3", ":memory:")
+	dsn := os.Getenv("TEST_DSN")
+	if dsn == "" {
+		t.Skip("no TEST_DSN environment variable set")
+		return
+	}
+
+	db, err := sqlx.Connect("postgres", dsn)
 	if err != nil {
 		t.Skip("no test database available:", err)
 		return
 	}
 
-	database.Setup(database.Options{Driver: "sqlite3"}, db)
+	database.Setup(database.Options{Driver: "postgres"}, db)
 	run(db)
 
 	db.Close()

--- a/datastore/helpers_test.go
+++ b/datastore/helpers_test.go
@@ -71,8 +71,17 @@ func withDatabase(t *testing.T, run func(db *sqlx.DB)) {
 		return
 	}
 
-	database.Setup(database.Options{Driver: "postgres"}, db)
+	err = database.Setup(database.Options{Driver: "postgres"}, db)
+	if err != nil {
+		panic(err)
+	}
+
 	run(db)
+
+	err = database.Teardown(database.Options{Driver: "postgres"}, db)
+	if err != nil {
+		panic(err)
+	}
 
 	db.Close()
 }
@@ -82,7 +91,6 @@ func withDatabaseFixtures(t *testing.T, run func(db *sqlx.DB)) {
 	withDatabase(t, func(db *sqlx.DB) {
 		loadDefaultFixture(db)
 		run(db)
-		db.Close()
 	})
 }
 

--- a/datastore/helpers_test.go
+++ b/datastore/helpers_test.go
@@ -71,17 +71,19 @@ func withDatabase(t *testing.T, run func(db *sqlx.DB)) {
 		return
 	}
 
+	// Ensure database is clean
+	err = database.Teardown(database.Options{Driver: "postgres"}, db)
+	if err != nil {
+		t.Log(err)
+	}
+
+	// Setup the schema
 	err = database.Setup(database.Options{Driver: "postgres"}, db)
 	if err != nil {
 		panic(err)
 	}
 
 	run(db)
-
-	err = database.Teardown(database.Options{Driver: "postgres"}, db)
-	if err != nil {
-		panic(err)
-	}
 
 	db.Close()
 }

--- a/datastore/helpers_test.go
+++ b/datastore/helpers_test.go
@@ -1,9 +1,17 @@
 package datastore
 
 import (
+	"testing"
+
 	"github.com/efy/gorecall/database"
 	"github.com/jmoiron/sqlx"
 )
+
+func TestWithFixtures(t *testing.T) {
+	withFixtures(t, func(db *sqlx.DB) {
+		t.Skip()
+	})
+}
 
 // Returns dependencies required for testing
 // tag repo
@@ -48,6 +56,23 @@ func testDB() *sqlx.DB {
 	database.Setup(database.Options{Driver: "sqlite3"}, db)
 
 	return db
+}
+
+// Function to wrap up tests against a postgres instance
+func withFixtures(t *testing.T, run func(db *sqlx.DB)) {
+	db, err := sqlx.Connect("postgres", "postgres://recall:recall@localhost/recall_test?sslmode=disable")
+	if err != nil {
+		t.Log("could not connect to test database")
+		t.Log(err)
+		t.Skip()
+		return
+	}
+
+	database.Setup(database.Options{Driver: "postgres"}, db)
+	loadDefaultFixture(db)
+	run(db)
+
+	db.Close()
 }
 
 // Fill the database with test data

--- a/datastore/helpers_test.go
+++ b/datastore/helpers_test.go
@@ -8,12 +8,6 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-func TestWithDatabase(t *testing.T) {
-	withDatabaseFixtures(t, func(db *sqlx.DB) {
-		t.Skip()
-	})
-}
-
 // Returns dependencies required for testing
 // tag repo
 func tagRepoTestDeps(db *sqlx.DB) *tagRepo {

--- a/datastore/tag_test.go
+++ b/datastore/tag_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/jmoiron/sqlx"
 )
 
 func TestNewTagRepo(t *testing.T) {
@@ -56,152 +58,153 @@ func TestTagValidate(t *testing.T) {
 }
 
 func TestTagRepoDelete(t *testing.T) {
-	db, tagRepo := tagRepoTestDeps()
-	loadDefaultFixture(db)
-	defer db.Close()
+	withDatabaseFixtures(t, func(db *sqlx.DB) {
+		tagRepo := tagRepoTestDeps(db)
 
-	err := tagRepo.Delete(1)
-	if err != nil {
-		t.Error(err)
-	}
+		err := tagRepo.Delete(1)
+		if err != nil {
+			t.Error(err)
+		}
+	})
 }
 
 func TestTagRepoCreate(t *testing.T) {
-	db, tagRepo := tagRepoTestDeps()
-	defer db.Close()
+	withDatabaseFixtures(t, func(db *sqlx.DB) {
+		tagRepo := tagRepoTestDeps(db)
 
-	tag := &Tag{
-		Label: "Create",
-	}
-	tag, err := tagRepo.Create(tag)
-	if err != nil {
-		t.Error("expected", nil)
-		t.Error("got     ", err)
-	}
-	if tag.Created.IsZero() {
-		t.Error("expected", "Create to be set by database")
-		t.Error("got     ", "Zero value date")
-	}
-	if tag.ID == 0 {
-		t.Error("expected", "ID to be set by database")
-		t.Error("got     ", "Zero value ID")
-	}
+		tag := &Tag{
+			Label: "Create",
+		}
+		tag, err := tagRepo.Create(tag)
+		if err != nil {
+			t.Error("expected", nil)
+			t.Error("got     ", err)
+		}
+		if tag.Created.IsZero() {
+			t.Error("expected", "Create to be set by database")
+			t.Error("got     ", "Zero value date")
+		}
+		if tag.ID == 0 {
+			t.Error("expected", "ID to be set by database")
+			t.Error("got     ", "Zero value ID")
+		}
+	})
 }
 
 func TestTagRepoGetByID(t *testing.T) {
-	db, tagRepo := tagRepoTestDeps()
-	loadDefaultFixture(db)
-	defer db.Close()
+	withDatabaseFixtures(t, func(db *sqlx.DB) {
+		tagRepo := tagRepoTestDeps(db)
 
-	tag, err := tagRepo.GetByID(1)
-	if err != nil {
-		t.Error(err)
-		t.Fail()
-	}
-	if tag.Label != "tag1" {
-		t.Error("expected", "tag1")
-		t.Error("got     ", tag.Label)
-	}
+		tag, err := tagRepo.GetByID(1)
+		if err != nil {
+			t.Error(err)
+			t.Fail()
+		}
+		if tag.Label != "tag1" {
+			t.Error("expected", "tag1")
+			t.Error("got     ", tag.Label)
+		}
+	})
 }
 
 func TestTagRepoGetByLabel(t *testing.T) {
-	db, tagRepo := tagRepoTestDeps()
-	loadDefaultFixture(db)
-	defer db.Close()
+	withDatabaseFixtures(t, func(db *sqlx.DB) {
+		tagRepo := tagRepoTestDeps(db)
 
-	_, err := tagRepo.GetByLabel("tag1")
-	if err != nil {
-		t.Fatal(err)
-	}
+		_, err := tagRepo.GetByLabel("tag1")
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 }
 
 func TestTagRepoCount(t *testing.T) {
-	db, tagRepo := tagRepoTestDeps()
-	loadDefaultFixture(db)
-	defer db.Close()
+	withDatabaseFixtures(t, func(db *sqlx.DB) {
+		tagRepo := tagRepoTestDeps(db)
 
-	count, err := tagRepo.Count()
-	if err != nil {
-		t.Error("expected", "no error")
-		t.Error("got     ", err)
-	}
+		count, err := tagRepo.Count()
+		if err != nil {
+			t.Error("expected", "no error")
+			t.Error("got     ", err)
+		}
 
-	if count != 3 {
-		t.Error("expected", 3)
-		t.Error("got     ", count)
-	}
+		if count != 3 {
+			t.Error("expected", 3)
+			t.Error("got     ", count)
+		}
+	})
 }
 
 func TestTagRepoList(t *testing.T) {
-	db, tagRepo := tagRepoTestDeps()
-	loadDefaultFixture(db)
-	defer db.Close()
+	withDatabaseFixtures(t, func(db *sqlx.DB) {
+		tagRepo := tagRepoTestDeps(db)
 
-	tags, err := tagRepo.List(DefaultListOptions)
-	if err != nil {
-		t.Error("expected", "no error")
-		t.Error("got     ", err)
-	}
+		tags, err := tagRepo.List(DefaultListOptions)
+		if err != nil {
+			t.Error("expected", "no error")
+			t.Error("got     ", err)
+		}
 
-	if len(tags) != 3 {
-		t.Error("expected", 3)
-		t.Error("got     ", len(tags))
-	}
+		if len(tags) != 3 {
+			t.Error("expected", 3)
+			t.Error("got     ", len(tags))
+		}
+	})
 }
 
 func TestTagRepoGetAll(t *testing.T) {
-	db, tagRepo := tagRepoTestDeps()
-	loadDefaultFixture(db)
-	defer db.Close()
+	withDatabaseFixtures(t, func(db *sqlx.DB) {
+		tagRepo := tagRepoTestDeps(db)
 
-	tags, err := tagRepo.GetAll()
-	if err != nil {
-		t.Error("expected", "no error")
-		t.Error("got     ", err)
-	}
+		tags, err := tagRepo.GetAll()
+		if err != nil {
+			t.Error("expected", "no error")
+			t.Error("got     ", err)
+		}
 
-	if len(tags) != 3 {
-		t.Error("expected", 3, "got", len(tags))
-	}
+		if len(tags) != 3 {
+			t.Error("expected", 3, "got", len(tags))
+		}
+	})
 }
 
 func TestTagRepoListBookmarks(t *testing.T) {
-	db, tagRepo := tagRepoTestDeps()
-	loadDefaultFixture(db)
-	defer db.Close()
+	withDatabaseFixtures(t, func(db *sqlx.DB) {
+		tagRepo := tagRepoTestDeps(db)
 
-	bookmarks, err := tagRepo.ListBookmarks(1, DefaultListOptions)
-	if err != nil {
-		t.Error("expected", "no error")
-		t.Error("got     ", err)
-	}
+		bookmarks, err := tagRepo.ListBookmarks(1, DefaultListOptions)
+		if err != nil {
+			t.Error("expected", "no error")
+			t.Error("got     ", err)
+		}
 
-	if len(bookmarks) != 3 {
-		t.Error("expected", 3)
-		t.Error("got     ", len(bookmarks))
-	}
+		if len(bookmarks) != 3 {
+			t.Error("expected", 3)
+			t.Error("got     ", len(bookmarks))
+		}
 
-	last := bookmarks[2]
+		last := bookmarks[2]
 
-	if last.Title != "bm3" {
-		t.Error("expected", "bm3")
-		t.Error("got     ", last.Title)
-	}
+		if last.Title != "bm3" {
+			t.Error("expected", "bm3")
+			t.Error("got     ", last.Title)
+		}
+	})
 }
 
 func TestTagRepoCountBookmarks(t *testing.T) {
-	db, tagRepo := tagRepoTestDeps()
-	loadDefaultFixture(db)
-	defer db.Close()
+	withDatabaseFixtures(t, func(db *sqlx.DB) {
+		tagRepo := tagRepoTestDeps(db)
 
-	count, err := tagRepo.CountBookmarks(1)
-	if err != nil {
-		t.Error("expected", "no error")
-		t.Error("got     ", err)
-	}
+		count, err := tagRepo.CountBookmarks(1)
+		if err != nil {
+			t.Error("expected", "no error")
+			t.Error("got     ", err)
+		}
 
-	if count != 3 {
-		t.Error("expected", 3)
-		t.Error("got     ", count)
-	}
+		if count != 3 {
+			t.Error("expected", 3)
+			t.Error("got     ", count)
+		}
+	})
 }

--- a/datastore/tag_test.go
+++ b/datastore/tag_test.go
@@ -42,18 +42,18 @@ func TestTagValidate(t *testing.T) {
 	}
 
 	for k, tr := range tt {
-		t.Log("running test case:", k)
+		t.Run(k, func(t *testing.T) {
+			valid, errs := tr.tag.Validate()
+			if valid != tr.valid {
+				t.Error("expected", tr.valid)
+				t.Error("got     ", valid)
+			}
 
-		valid, errs := tr.tag.Validate()
-		if valid != tr.valid {
-			t.Error("expected", tr.valid)
-			t.Error("got     ", valid)
-		}
-
-		if !reflect.DeepEqual(errs, tr.errs) {
-			t.Error("expected", tr.errs)
-			t.Error("got     ", errs)
-		}
+			if !reflect.DeepEqual(errs, tr.errs) {
+				t.Error("expected", tr.errs)
+				t.Error("got     ", errs)
+			}
+		})
 	}
 }
 

--- a/datastore/user_test.go
+++ b/datastore/user_test.go
@@ -1,6 +1,10 @@
 package datastore
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+)
 
 func TestNewUserRepo(t *testing.T) {
 	expect := ErrInvalidDB
@@ -12,82 +16,83 @@ func TestNewUserRepo(t *testing.T) {
 }
 
 func TestUserRepoCreate(t *testing.T) {
-	db, userRepo := userRepoTestDeps()
-	defer db.Close()
+	withDatabaseFixtures(t, func(db *sqlx.DB) {
+		userRepo := userRepoTestDeps(db)
 
-	user := &User{
-		Username: "test",
-		Password: "abc123",
-	}
+		user := &User{
+			Username: "test",
+			Password: "abc123",
+		}
 
-	user, err := userRepo.Create(user)
-	if err != nil {
-		t.Error(err)
-	}
+		user, err := userRepo.Create(user)
+		if err != nil {
+			t.Error(err)
+		}
 
-	if user.Created.IsZero() {
-		t.Error("expected", ".Created to be set in database")
-		t.Error("got     ", user.Created)
-	}
+		if user.Created.IsZero() {
+			t.Error("expected", ".Created to be set in database")
+			t.Error("got     ", user.Created)
+		}
 
-	if user.ID == 0 {
-		t.Error("expected", ".ID to be set in database")
-		t.Error("got     ", user.ID)
-	}
+		if user.ID == 0 {
+			t.Error("expected", ".ID to be set in database")
+			t.Error("got     ", user.ID)
+		}
+	})
 }
 
 func TestUserRepoUpdate(t *testing.T) {
-	db, userRepo := userRepoTestDeps()
-	loadDefaultFixture(db)
-	defer db.Close()
+	withDatabaseFixtures(t, func(db *sqlx.DB) {
+		userRepo := userRepoTestDeps(db)
 
-	user, err := userRepo.GetByID(1)
-	if err != nil {
-		t.Fatal(err)
-	}
+		user, err := userRepo.GetByID(1)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	user.Username = "updated"
+		user.Username = "updated"
 
-	user, err = userRepo.Update(user)
-	if err != nil {
-		t.Fatal(err)
-	}
+		user, err = userRepo.Update(user)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 }
 
 func TestUserRepoGet(t *testing.T) {
-	db, userRepo := userRepoTestDeps()
-	loadDefaultFixture(db)
-	defer db.Close()
+	withDatabaseFixtures(t, func(db *sqlx.DB) {
+		userRepo := userRepoTestDeps(db)
 
-	user, err := userRepo.GetByID(1)
-	if err != nil {
-		t.Error(err)
-	}
-	if user.Username != "testuser1" {
-		t.Error("expected", ".Username to be 'testuser1'")
-		t.Error("got     ", user.Username)
-	}
+		user, err := userRepo.GetByID(1)
+		if err != nil {
+			t.Error(err)
+		}
+		if user.Username != "testuser1" {
+			t.Error("expected", ".Username to be 'testuser1'")
+			t.Error("got     ", user.Username)
+		}
 
-	user, err = userRepo.GetByUsername("testuser1")
-	if err != nil {
-		t.Error(err)
-	}
-	if user.ID != 1 {
-		t.Error("expected", ".ID to equal 1")
-		t.Error("got     ", user.ID)
-	}
+		user, err = userRepo.GetByUsername("testuser1")
+		if err != nil {
+			t.Error(err)
+		}
+		if user.ID != 1 {
+			t.Error("expected", ".ID to equal 1")
+			t.Error("got     ", user.ID)
+		}
 
-	_, err = userRepo.GetByUsername("nouser")
-	if err == nil {
-		t.Error("expect error when non existent")
-	}
+		_, err = userRepo.GetByUsername("nouser")
+		if err == nil {
+			t.Error("expect error when non existent")
+		}
 
-	users, err := userRepo.GetAll()
-	if err != nil {
-		t.Error(err)
-	}
-	if len(users) != 2 {
-		t.Error("expected", "total of 2 users")
-		t.Error("got     ", len(users))
-	}
+		users, err := userRepo.GetAll()
+		if err != nil {
+			t.Error(err)
+		}
+		if len(users) != 2 {
+			t.Error("expected", "total of 2 users")
+			t.Error("got     ", len(users))
+		}
+	})
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3'
+services:
+  db:
+    image: postgres
+    environment:
+      POSTGRES_DB: recall_development
+      POSTGRES_USER: recall
+      POSTGRES_PASSWORD: recall
+    ports:
+      - 5432:5432
+  app:
+    build: .
+    command: ["/go/bin/recall", "serve"]
+    volumes:
+      - .:/go/src/app
+    ports:
+      - "80:8080"
+    depends_on:
+      - db
+    links:
+      - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - 5432:5432
   app:
     build: .
-    command: ["/go/bin/recall", "serve"]
+    command: ["/go/bin/recall", "serve", "-secret=vBBB12NsG2YOJyLwmGUZ1YvLgTWvYyAOQM+CgVrgfK0="]
     volumes:
       - .:/go/src/app
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  db:
+  postgres:
     image: postgres
     environment:
       POSTGRES_DB: recall_development
@@ -10,12 +10,20 @@ services:
       - 5432:5432
   app:
     build: .
-    command: ["/go/bin/recall", "serve", "-secret=vBBB12NsG2YOJyLwmGUZ1YvLgTWvYyAOQM+CgVrgfK0="]
+    command: [
+      "./bin/wait-for-it.sh", 
+      "postgres:5432",
+      "--",
+      "/go/bin/recall", 
+      "serve", 
+      "-dsn=postgress://recall:recall@localhost/recall_development?sslmode=disable", 
+      "-secret=vBBB12NsG2YOJyLwmGUZ1YvLgTWvYyAOQM+CgVrgfK0="
+    ]
     volumes:
       - .:/go/src/app
     ports:
       - "80:8080"
     depends_on:
-      - db
+      - postgres
     links:
-      - db
+      - postgres

--- a/main.go
+++ b/main.go
@@ -41,5 +41,5 @@ func main() {
 	}
 
 	// Handle invalid / unknown command
-	fmt.Fprintf(os.Stderr, "gorecall: unknown subcommand %q\nRun 'temple help' for usage.\n", os.Args[1])
+	fmt.Fprintf(os.Stderr, "gorecall: unknown subcommand %q\nRun 'gorecall help' for usage.\n", os.Args[1])
 }


### PR DESCRIPTION
Removes dependance on sqlite3 in favour of targeting only Postgres. This simplifies build process and deployment. New application features can also rely on a consistent set of database features rather than be hamstrung by commonalities between sqlite and Postgres.